### PR TITLE
Fix charm option description field

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -49,7 +49,7 @@ config:
       type: string
       default: ""
     nts-certificates:
-      descriptions: >-
+      description: >-
         A comma-separated list of juju secret IDs for enabling NTS with. 
         Each juju secret ID must be a juju secret URI (i.e. start with `secret:`). 
         The secret must include two fields: the `cert` field, which contains the PEM-encoded TLS certificate, 


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Update `descriptions` to `description` in `charmcraft.yaml` so charm config description is rendered correctly.

### Rationale

To improve charm documentation on charmhub.

### Juju Events Changes

N/A

### Module Changes

N/A

### Library Changes

N/A

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
