### PR TITLE
Update README to refer to Matrix rather than Mattermost for community chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ open source project that warmly welcomes community projects, contributions,
 suggestions, fixes and constructive feedback.
 * [Code of conduct](https://ubuntu.com/community/code-of-conduct)
 * [Get support](https://discourse.charmhub.io/)
-* [Join our online chat](https://chat.charmhub.io/charmhub/channels/charm-dev)
+* [Join our online chat](https://matrix.to/#/#charmhub-charmdev:ubuntu.com)
 * [Contribute](https://charmhub.io/chrony/docs/contributing)
 * [Roadmap](https://charmhub.io/chrony/docs/roadmap)
-Thinking about using the Chrony charm for your next project? [Get in touch](https://chat.charmhub.io/charmhub/channels/charm-dev)!
+Thinking about using the Chrony charm for your next project? [Get in touch](https://matrix.to/#/#charmhub-charmdev:ubuntu.com)!
 
 ---
 


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Update links to refer to Matrix instead of Mattermost.

### Rationale

Community discussions now happen on Matrix.

### Juju Events Changes

N/A

### Module Changes

N/A

### Library Changes

N/A

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
