### PR TITLE
Add how-to guides

### DIFF
--- a/docs/how-to/enable-nts.md
+++ b/docs/how-to/enable-nts.md
@@ -1,0 +1,43 @@
+# How to: Enable NTS (Network Time Security)
+
+Network Time Security (NTS) is a mechanism that uses Transport Layer Security
+(TLS) and Authenticated Encryption with Associated Data (AEAD) to provide 
+cryptographic security for the client-server mode of the Network Time Protocol
+(NTP).
+
+When a TLS certificate is provided to the Chrony charm, Chrony will 
+automatically enable NTS, allowing NTS-capable NTP clients to securely
+communicate with the Chrony charm. 
+You can use one of the following options to configure the TLS certificate
+used for NTS.
+
+## `tls-certificates` integration
+
+The Chrony charm can integrate with any charm that provides `tls-certificates` 
+integration, such as the [`lego`](https://charmhub.io/lego) or 
+[`self-signed-certificates`](https://charmhub.io/self-signed-certificates) 
+charms. 
+Refer to the respective `tls-certificates` provider charm's documentation 
+for setup instructions. 
+Once set up, you can integrate the `tls-certificates` provider charm with 
+the Chrony charm:
+
+```
+juju integrate chrony:nts-certificates self-signed-certificates
+```
+
+## `nts-certificates` charm configuration
+
+The Chrony charm includes a configuration option, `nts-certificates`, which 
+can be used to provide existing TLS certificates directly to the Chrony 
+charm. This is especially useful if you want to generate a 
+[TLS certificate with an extended validity period for use with NTS clients lacking a real-time clock](https://chrony-project.org/faq.html#_using_nts). 
+
+The TLS certificate must be stored in [a Juju user secret](https://juju.is/docs/juju/manage-secrets#add-a-secret) 
+before being passed to the Chrony charm.
+
+```
+juju add-secret my-tls-cert cert#file=/path/to/fullchain.pem key#file=/path/to/key.pem
+juju grant-secret my-tls-cert chrony
+juju config chrony nts-certificates=secret:...
+```

--- a/docs/how-to/enable-nts.md
+++ b/docs/how-to/enable-nts.md
@@ -39,5 +39,5 @@ before being passed to the Chrony charm.
 ```
 juju add-secret my-tls-cert cert#file=/path/to/fullchain.pem key#file=/path/to/key.pem
 juju grant-secret my-tls-cert chrony
-juju config chrony nts-certificates=secret:...
+juju config chrony nts-certificates=<output from juju add-secret>
 ```

--- a/docs/how-to/enable-nts.md
+++ b/docs/how-to/enable-nts.md
@@ -1,4 +1,4 @@
-# How to: Enable NTS (Network Time Security)
+# How to enable Network Time Security
 
 Network Time Security (NTS) is a mechanism that uses Transport Layer Security
 (TLS) and Authenticated Encryption with Associated Data (AEAD) to provide 
@@ -20,7 +20,7 @@ charms.
 Refer to the respective `tls-certificates` provider charm's documentation 
 for setup instructions. 
 Once set up, you can integrate the `tls-certificates` provider charm with 
-the Chrony charm:
+the Chrony charm using the `juju integrate` command:
 
 ```
 juju integrate chrony:nts-certificates self-signed-certificates

--- a/docs/how-to/setup-time-sources.md
+++ b/docs/how-to/setup-time-sources.md
@@ -1,0 +1,28 @@
+# How to: Setup Time Sources
+
+Chrony alone cannot provide time; it requires another time source, either a 
+reference clock or another NTP server, to supply time to Chrony itself. 
+Currently, the Chrony charm supports only using another NTP server as the 
+time source.
+
+## Use Another NTP Server
+
+Provide the IP address or domain name of the NTP server to be used as the time 
+source in URL format, for example, `ntp://ntp.example.com`. 
+Pass this URL to the Chrony charm using the `sources` charm configuration. 
+The domain in the URL will be treated as a pool address for the NTP server.
+
+You can adjust the time source using 
+[pool options listed in the Chrony configuration](https://chrony-project.org/doc/4.6.1/chrony.conf.html). 
+These options are passed to the Chrony charm as URL parameters. 
+For example, to enable `iburst` and set `maxsources` to 2, use the 
+URL `ntp://ntp.example.com?iburst=true&maxsources=2`. 
+The only exception option is NTS, as explained in the next section.
+
+## Use Another NTS Server with NTS Enabled
+
+To use another NTS server with NTS enabled for the time source, follow a 
+similar process as using an NTP server but change the protocol to `nts`.
+For example, use `nts://ntp.example.com`. 
+All pool options available for a plain NTP time source are also 
+applicable to an NTS time source.

--- a/docs/how-to/setup-time-sources.md
+++ b/docs/how-to/setup-time-sources.md
@@ -1,15 +1,15 @@
-# How to: Setup Time Sources
+# How to set up time sources
 
 Chrony alone cannot provide time; it requires another time source, either a 
 reference clock or another NTP server, to supply time to Chrony itself. 
-Currently, the Chrony charm supports only using another NTP server as the 
+Currently, the Chrony charm only supports using another NTP server as the 
 time source.
 
-## Use Another NTP Server
+## Use another NTP server
 
 Provide the IP address or domain name of the NTP server to be used as the time 
-source in URL format, for example, `ntp://ntp.example.com`. 
-Pass this URL to the Chrony charm using the `sources` charm configuration. 
+source in URL format, for example, `ntp://ntp.example.com`, and pass this URL to
+the Chrony charm using the `sources` charm configuration. 
 The domain in the URL will be treated as a pool address for the NTP server.
 
 You can adjust the time source using 
@@ -19,7 +19,7 @@ For example, to enable `iburst` and set `maxsources` to 2, use the
 URL `ntp://ntp.example.com?iburst=true&maxsources=2`. 
 The only exception option is NTS, as explained in the next section.
 
-## Use Another NTS Server with NTS Enabled
+## Use another NTS server with NTS enabled
 
 To use another NTS server with NTS enabled for the time source, follow a 
 similar process as using an NTP server but change the protocol to `nts`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,17 +4,17 @@ A [Juju](https://juju.is/) [charm](https://juju.is/docs/olm/charmed-operators)
 for deploying and managing the [Chrony](https://chrony-project.org) NTP server
 in your systems.
 
-This charm simplifies the configuration and maintenance of `chrony` across a
+This charm simplifies the configuration and maintenance of Chrony across a
 range of environments, enabling basic time provision and synchronization with
 NTP servers.
 
 Like any Juju charm, this charm supports one-line deployment, configuration, integration, scaling, and more. 
 For Chrony, this includes: 
-* time source management
+* Time source management
 * NTS (Network Time Security) and NTS certificate management
 * Enhanced observability and monitoring
 
-The Chrony charm allows for deployment on many different virtualization platforms, from [lxd](https://canonical.com/lxd) to 
+The Chrony charm allows for deployment on many different virtualization platforms, from [LXD](https://canonical.com/lxd) to 
 [OpenStack](https://ubuntu.com/openstack) to public cloud offerings.
 
 This charm will make operating Chrony  simple and straightforward for DevOps or SRE teams through Juju's clean interface. 
@@ -48,7 +48,7 @@ projects, contributions, suggestions, fixes, and constructive feedback.
 - [Join our online chat](https://matrix.to/#/#charmhub-charmdev:ubuntu.com)
 - [Contribute](https://github.com/canonical/chrony-operator/blob/main/CONTRIBUTING.md)
 
-Thinking about using the <charm-name> Operator for your next project? 
+Thinking about using the Chrony Operator for your next project? 
 [Get in touch](https://matrix.to/#/#charmhub-charmdev:ubuntu.com)!
 
 # Contents

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,30 +1,59 @@
-A [Juju](https://juju.is/) [charm](https://juju.is/docs/olm/charmed-operators) 
-for deploying and managing the [Chrony](https://chrony-project.org) NTP server 
+# Chrony Operator
+
+A [Juju](https://juju.is/) [charm](https://juju.is/docs/olm/charmed-operators)
+for deploying and managing the [Chrony](https://chrony-project.org) NTP server
 in your systems.
 
-This charm simplifies the configuration and maintenance of `chrony` across a 
-range of environments, enabling basic time provision and synchronization with 
+This charm simplifies the configuration and maintenance of `chrony` across a
+range of environments, enabling basic time provision and synchronization with
 NTP servers.
 
-## Project and community
+Like any Juju charm, this charm supports one-line deployment, configuration, integration, scaling, and more. 
+For Chrony, this includes: 
+* time source management
+* NTS (Network Time Security) and NTS certificate management
+* Enhanced observability and monitoring
 
-The Chrony Operator is a member of the Ubuntu family. It's an
-open source project that warmly welcomes community projects, contributions,
-suggestions, fixes and constructive feedback.
-* [Code of conduct](https://ubuntu.com/community/code-of-conduct)
-* [Get support](https://discourse.charmhub.io/)
-* [Join our online chat](https://matrix.to/#/#charmhub-charmdev:ubuntu.com)
-* [Contribute](https://charmhub.io/chrony/docs/contributing)
-* [Roadmap](https://charmhub.io/chrony/docs/roadmap)
-Thinking about using the Chrony charm for your next project? [Get in touch](https://matrix.to/#/#charmhub-charmdev:ubuntu.com)!
+The Chrony charm allows for deployment on many different virtualization platforms, from [lxd](https://canonical.com/lxd) to 
+[OpenStack](https://ubuntu.com/openstack) to public cloud offerings.
+
+This charm will make operating Chrony  simple and straightforward for DevOps or SRE teams through Juju's clean interface. 
+
+## In this documentation
+
+|                                                                                                                                           |                                                                                                                              |
+|-------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------|
+| [Tutorials](https://charmhub.io/chrony/docs/Tutorials)</br>  Get started - a hands-on introduction to using the charm for new users </br> | [How-to guides](https://charmhub.io/chrony/docs/How%20To) </br> Step-by-step guides covering key operations and common tasks |
+| [Reference](https://charmhub.io/chrony/docs/Reference) </br> Technical information - specifications, APIs, architecture                                           | [Explanation](https://charmhub.io/chrony/docs/Explanation) </br> Concepts - discussion and clarification of key topics                               |
 
 ## Contributing to this documentation
 
-Documentation is an important part of this project, and we take the same open-source approach to the documentation as the code. As such, we welcome community contributions, suggestions and constructive feedback on our documentation. Our documentation is hosted on the [Charmhub forum](https://discourse.charmhub.io/) to enable easy collaboration. Please use the "Help us improve this documentation" links on each documentation page to either directly change something you see that's wrong, or ask a question, or make a suggestion about a potential change via the comments section.
+Documentation is an important part of this project, and we take the same open-source approach to the documentation as 
+the code. As such, we welcome community contributions, suggestions and constructive feedback on our documentation. 
+Our documentation is hosted on the [Charmhub forum](https://discourse.charmhub.io/) 
+to enable easy collaboration. Please use the "Help us improve this documentation" links on each documentation page to 
+either directly change something you see that's wrong, ask a question or make a suggestion about a potential change via 
+the comments section.
 
-If there's a particular area of documentation that you'd like to see that's missing, please [file a bug](https://github.com/canonical/chrony-operator/issues).
+If there's a particular area of documentation that you'd like to see that's missing, please 
+[file a bug](https://github.com/canonical/chrony-operator/issues).
 
-# In this documentation
-|                                                            ||
-|------------------------------------------------------------|----------------|
-| [Tutorial](tutorial)</br>  Hands-on introduction to Chrony ||
+## Project and community
+
+The Chrony Operator is a member of the Ubuntu family. It's an open-source project that warmly welcomes community 
+projects, contributions, suggestions, fixes, and constructive feedback.
+
+- [Code of conduct](https://ubuntu.com/community/code-of-conduct)
+- [Get support](https://discourse.charmhub.io/)
+- [Join our online chat](https://matrix.to/#/#charmhub-charmdev:ubuntu.com)
+- [Contribute](https://github.com/canonical/chrony-operator/blob/main/CONTRIBUTING.md)
+
+Thinking about using the <charm-name> Operator for your next project? 
+[Get in touch](https://matrix.to/#/#charmhub-charmdev:ubuntu.com)!
+
+# Contents
+
+1. [Tutorial](https://charmhub.io/chrony/docs/Tutorials)
+1. [How-to](https://charmhub.io/chrony/docs/How%20To)
+1. [Reference](https://charmhub.io/chrony/docs/Reference)
+1. [Explanation](https://charmhub.io/chrony/docs/Explanation)


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Add two how-to guides: one on setting up the NTS and another on configuring the time sources for the Chrony charm.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
